### PR TITLE
fix ListExtensionsParameters extensionNumber

### DIFF
--- a/provisioning/extensions/get-extension-list/code-samples/listExtensions.cs
+++ b/provisioning/extensions/get-extension-list/code-samples/listExtensions.cs
@@ -6,7 +6,7 @@ string accountId = "<ENTER VALUE>";
 
 // OPTIONAL QUERY PARAMETERS
 ListExtensionsParameters listExtensionsParameters = new ListExtensionsParameters {
-    //extensionId = "<ENTER VALUE>",
+    //extensionNumber = "<ENTER VALUE>",
     //email = "<ENTER VALUE>",
     //page = 1,
     //perPage = 100,


### PR DESCRIPTION
Fix get-extension-list sample code - optional parameters ListExtensionsParameters "extensionId" should be "extensionNumber". Is this code auto-generated?